### PR TITLE
Add naive import syntax support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -185,7 +185,20 @@ class Renderer {
           line = line.replace(/\s.*/, '');
         }
       } else if (runArgs && /^```/.test(line)) {
-        const script = scriptLines.join('\n');
+        const script = scriptLines
+          .join('\n')
+          .replace(
+            /import\s*\{\s*([^\s]+)\s+as\s+([^\s]+)\s*\}\s*from\s*['"]([^']+)['"]/g,
+            'const { $1: $2 } = require("$3")',
+          ) // Naive esmodule import support: "import { X as Y } from 'Z'"
+          .replace(
+            /import\s*\{\s*([^\s]+)\s*\}\s*from\s*['"]([^']+)['"]/g,
+            'const { $1 } = require("$2")',
+          ) // Naive esmodule import support: "import { X } from 'Z'"
+          .replace(
+            /import\s([^\s]+)\sfrom\s*['"]([^']+)['"]/g,
+            'const $1 = require("$2")',
+          ); // Naive esmodule import support: "import X from 'Z'"
         scriptLines.length = 0;
         write('');
 


### PR DESCRIPTION
Given running esmodules in a node vm to truly evaluate code snippets as
esmodules is still experimental and pretty low level
(https://nodejs.org/docs/latest-v12.x/api/vm.html#vm_class_vm_module)
this hack might work in many cases already.

Demo:

```javascript
console.log(
`
import { v1 as uuidv1 } from 'uuid';
import { v1 } from 'uuid';
import uuid from 'uuid';
import {
  v1 as uuidv1
} from 'uuid';
`
.replace(
  /import\s*\{\s*([^\s]+)\s+as\s+([^\s]+)\s*\}\s*from\s*['"]([^']+)['"]/g,
  'const { $1: $2 } = require("$3")',
)
.replace(
  /import\s*\{\s*([^\s]+)\s*\}\s*from\s*['"]([^']+)['"]/g,
  'const { $1 } = require("$2")',
)
.replace(
  /import\s([^\s]+)\sfrom\s*['"]([^']+)['"]/g,
  'const $1 = require("$2")',
)
);
```

Output:

```
const { v1: uuidv1 } = require("uuid");
const { v1 } = require("uuid");
const uuid = require("uuid");
const { v1: uuidv1 } = require("uuid");
```