### PR TITLE
Updated Logo link from http to https

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,7 +294,7 @@ function render(inputText, options = {}) {
     }
   });
 
-  const LINK = '[![RunMD Logo](http://i.imgur.com/h0FVyzU.png)](https://github.com/broofa/runmd)';
+  const LINK = '[![RunMD Logo](https://i.imgur.com/h0FVyzU.png)](https://github.com/broofa/runmd)';
   if (!lame) {
     _write('----');
     _write(outputName ?


### PR DESCRIPTION
The HTTP link causes the browser to a non-secure warning for all packages using this library

![image](https://user-images.githubusercontent.com/283631/94890165-2e1d1800-049c-11eb-955d-5af652c80d93.png)
